### PR TITLE
Use proper make arguments 

### DIFF
--- a/compiler/nose.vim
+++ b/compiler/nose.vim
@@ -21,4 +21,4 @@ if exists(":CompilerSet") != 2 " older Vim always used :setlocal
 endif
 
 CompilerSet efm=%f:%l:\ fail:\ %m,%f:%l:\ error:\ %m
-CompilerSet makeprg=echo\ $*\ >/dev/null;\ nosetests\ %\ -q\ --with-doctest\ --with-machineout
+CompilerSet makeprg=nosetests\ $*\ -q\ --with-doctest\ --with-machineout


### PR DESCRIPTION
I wanted to write a vim binding to run all tests in a directory with  nose, it took a minute to realize why it wasn't working, but the plugin currently doesn't use the arguments passed into `make`. It's an easy fix.

Since it seems like this was created in order to run with `MakeGreen()`, it isn' an issue, since `MakeGreen()` by default uses the `%` (current file) argument. 

I use the following mappings

```
nnoremap <Leader>t :call MakeGreen('%')<CR>
nnoremap <Leader>at :call MakeGreen('.')<CR>
```

Where `<Leader>at` runs nose on the whole directory, rather than the whole file. Useful to see the output of all tests.

The fix was simple, and thought I would submit a pull request to the 'official' repo.

Cheers
